### PR TITLE
Working-branch pull request New-York-Times home page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-package.json
 .hintrc
 package-lock.json
 .stylelintrc.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![screenshot](/images/Screenshot.png)
 
-The project is about a clone from New York Times homepage.
+The project is about a clone from New York Times homepage. We used flexbox for nav-bar section, grid for the final article section and for the "more in the space and astronomy" section, float and absolutes properties to layout the whole page. we used use <aside> tag for Editor's picks section on the rightmost side.
 
 ## Built With
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![screenshot](/images/Screenshot.png)
 
-The project is about a clone from New York Times homepage. We used flexbox for nav-bar section, grid for the final article section and for the "more in the space and astronomy" section, float and absolutes properties to layout the whole page. we used use <aside> tag for Editor's picks section on the rightmost side.
+The project is about a clone from New York Times homepage. We used flexbox for nav-bar section, grid for the final article section and for the "more in the space and astronomy" section, float and absolutes properties to layout the whole page. we used use "aside" tag for Editor's picks section on the rightmost side.
 
 ## Built With
 

--- a/index.html
+++ b/index.html
@@ -271,6 +271,10 @@
 					<p class="img-date">Aug. 10</p>
 				</div>
 				<div class="img-3 moreInSpace-imgs-container">
+					<img class= "moreInSpace-imgs" src="https://static01.nyt.com/images/2020/08/03/reader-center/03sci-splashdown-floater-A1/03sci-splashdown-floater-A1-threeByTwoSmallAt2X.jpg?quality=75&auto=webp&disable=upscale" alt="">
+					<p class="img-footer">Bill Ingalls/NASA, via Agence France-Presse — Getty Images</p>
+					<p class="img-title">‘Thanks for Flying SpaceX’: NASA Astronauts Safely Splash Down After Journey From Orbit</p>
+					<p class="img-date">Aug. 2</p>
 				</div>
 				<div class="img-4 moreInSpace-imgs-container">
 					<img class= "moreInSpace-imgs" src="https://static01.nyt.com/images/2020/08/11/science/00SCI-OUTTHERE-promo/00SCI-OUTTHERE-promo-threeByTwoSmallAt2X.jpg?quality=75&auto=webp&disable=upscale" alt="">

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
                 <a class="anchor-nav-a" href="">SPACE & COSMOS</a>
             </div>
         </div>
-        <img src="images/The-New-York-Times.svg" alt="" class="img-nav">        
+        <a href="https://www.nytimes.com/"><img src="images/The-New-York-Times.svg" alt="" class="img-nav"></a>        
         <div class="btn-nav">
             <button name="subscribe" type="submit" class="btn fw-bold">SUBSCRIBE NOW</button>
             <button name="login" type="submit" class="btn fw-bold">LOG IN</button>


### PR DESCRIPTION
We used flexbox for nav-bar section, grid for the final article section and for the "more in the space and astronomy" section,. We used CSS float and absolutes properties to layout the whole page. we used "aside" tag for Editor's picks section on the rightmost side and "articles" for "more in the space and astronomy" section.